### PR TITLE
close app on quit window

### DIFF
--- a/ui/src-tauri/src/main.rs
+++ b/ui/src-tauri/src/main.rs
@@ -355,8 +355,6 @@ fn main() {
             api.prevent_close();
             match label.as_str() {
                 "about" => app.get_window(&label).unwrap().hide().unwrap(),
-                // TODO: close app on login or create account page, otherwise
-                // cancel transaction and close window
                 "main" => app.exit(0),
                 _ => unreachable!("There are no other windows."),
             }

--- a/ui/src-tauri/src/main.rs
+++ b/ui/src-tauri/src/main.rs
@@ -355,9 +355,9 @@ fn main() {
             api.prevent_close();
             match label.as_str() {
                 "about" => app.get_window(&label).unwrap().hide().unwrap(),
-                "main" => {
-                    // TODO: For the create account / login page, run `app.exit(0)`.
-                }
+                // TODO: close app on login or create account page, otherwise
+                // cancel transaction and close window
+                "main" => app.exit(0),
                 _ => unreachable!("There are no other windows."),
             }
         }


### PR DESCRIPTION
Currently, the main window of Signer won't close (or do anything) if you click the red dot on mac (or X on windows). This PR changes behavior so that Signer quits entirely when you click the red dot on mac (or X on windows).