### PR TITLE
increase timeout

### DIFF
--- a/js/signer-interface/package.json
+++ b/js/signer-interface/package.json
@@ -1,6 +1,6 @@
 {
     "name": "signer-interface",
-    "version": "0.2.0",
+    "version": "0.2.1",
     "main": "dist/index.js",
     "description": "JS interface for interacting with Manta Signer",
     "types": "dist/index.d.ts",

--- a/js/signer-interface/src/interface/signerClient.ts
+++ b/js/signer-interface/src/interface/signerClient.ts
@@ -10,7 +10,7 @@ export class SignerClient {
 
   async getSignerVersion() {
     try {
-      const res = await axios.get('version', { timeout: 200 });
+      const res = await axios.get('version', { timeout: 500 });
       return res.data.version;
     } catch (timeoutError) {
       return null;


### PR DESCRIPTION
Increase timeout on signer interface version check. This is a temporary hack to prevent periodic disconnection on Windows OS--but long term it should not be necessary to tolerate such weirdly high latency on localhost.

- [x] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [n/a] Test following procedure in docs/testing-workflow.md
- [n/a] Updated relevant documentation in the code.
- [x] Re-reviewed `Files changed` in the Github PR explorer.
- [n/a] Update the version numbers properly:
   * Cargo.toml
   * ui/src-tauri/Cargo.toml
   * ui/src-tauri/tauri.conf.json
   * ui/public/about.html
   * ui/package.json
