### PR TITLE
fix: remove macos 10.15 from CI [#none]

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,12 +46,6 @@ jobs:
             asset_name: manta-signer-macos-amd64
             version_suffix: 3
             target: darwin
-          - os: macos-10.15
-            os_type: macos
-            artifact_name: manta-signer
-            asset_name: manta-signer-macos-amd64
-            version_suffix: 4
-            target: darwin
     steps:
       - name: Checkout code
         uses: actions/checkout@v3


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

Tauri no longer has issues between macOS 10.15 and macOS latest, so we can just use a unified build.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Test following procedure in docs/testing-workflow.md
- [x] Updated relevant documentation in the code.
- [x] Re-reviewed `Files changed` in the Github PR explorer.
- [x] Update the version numbers properly:
   * Cargo.toml
   * ui/package.json
   * ui/public/about.html
   * ui/src-tauri/Cargo.toml
   * ui/src-tauri/tauri.conf.json