### PR TITLE
highlight recovery phrase selection;

### DIFF
--- a/ui/src/App.css
+++ b/ui/src/App.css
@@ -25,7 +25,7 @@
 
 .authorize-summary {
     inline-size: 26rem;
-    margin:0 auto;
+    margin: 0 auto;
     max-width: 22.5rem !important;
     overflow-wrap: break-word;
     text-align: center;
@@ -36,7 +36,7 @@
     text-align: center;
 }
 
-.recovery-phrase-info > p {
+.recovery-phrase-info>p {
     margin: 0;
 }
 
@@ -54,6 +54,11 @@
     min-width: 10rem;
     padding: 0.5rem;
     text-align: center;
+}
+
+.recovery-phrase::selection {
+    color: white;
+    background-color: darkblue;
 }
 
 .recovery-phrase-header {


### PR DESCRIPTION
## Description

When selecting the text in the recovery phrase section, because of the current light-blue background color, users may select only part of the mnemonic without noticing. Changing the css of the selection makes the selection obvious.

changes copied from #90 , because signer CI is failing to build signer on that branch, possibly because PR is from external contributor

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Test following procedure in docs/testing-workflow.md
- [x] Updated relevant documentation in the code.
- [x] Re-reviewed `Files changed` in the Github PR explorer.
- [x] Update the version numbers properly:
   * Cargo.toml
   * ui/package.json
   * ui/public/about.html
   * ui/src-tauri/Cargo.toml
   * ui/src-tauri/tauri.conf.json