### PR TITLE
downgrade manta-rs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - run: rustup update nightly && rustup default nightly
-      - run: RUSTDOCFLAGS="-D warnings --cfg doc_cfg" cargo +nightly doc --all-features --no-deps --document-private-items # FIXME: Running this on the Tauri library does not work.
+      - run: RUSTDOCFLAGS="-D warnings --cfg doc_cfg" cargo +nightly doc --all-features --no-deps --document-private-items
   lint:
     name: Lint (${{ matrix.os }} + ${{ matrix.channel }})
     needs: [format, format-cargo-toml, docs]
@@ -52,10 +52,10 @@ jobs:
       - uses: actions/checkout@v3
       - run: rustup update ${{ matrix.channel }} && rustup default ${{ matrix.channel }} && rustup component add clippy
       - run: cargo install cargo-hack
-      - run: cargo hack clippy --workspace --feature-powerset
-      - run: cargo hack clippy --workspace --feature-powerset --bins
-      - run: cargo hack clippy --workspace --feature-powerset --examples
-      - run: cargo hack clippy --workspace --feature-powerset --tests
+      - run: cargo hack clippy --feature-powerset
+      - run: cargo hack clippy --feature-powerset --bins
+      - run: cargo hack clippy --feature-powerset --examples
+      - run: cargo hack clippy --feature-powerset --tests
   test:
     name: Test (${{ matrix.os }} + ${{ matrix.channel }})
     needs: [format, format-cargo-toml, docs]
@@ -74,7 +74,7 @@ jobs:
       - uses: actions/checkout@v3
       - run: rustup update ${{ matrix.channel }} && rustup default ${{ matrix.channel }}
       - run: cargo install cargo-nextest
-      - run: cargo nextest run --workspace --release --all-features
+      - run: cargo nextest run --release --all-features
   compile-bench:
     name: Compile Benchmarks (${{ matrix.os }} + ${{ matrix.channel }})
     needs: [format, format-cargo-toml, docs]
@@ -92,4 +92,4 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - run: rustup update ${{ matrix.channel }} && rustup default ${{ matrix.channel }}
-      - run: cargo bench --workspace --no-run --all-features
+      - run: cargo bench --no-run --all-features

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - run: rustup update nightly && rustup default nightly
-      - run: RUSTDOCFLAGS="-D warnings --cfg doc_cfg" cargo +nightly doc --workspace --all-features --no-deps --document-private-items
+      - run: cargo doc --workspace --all-features --no-deps --document-private-items
   lint:
     name: Lint (${{ matrix.os }} + ${{ matrix.channel }})
     needs: [format, format-cargo-toml, docs]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - run: rustup update nightly && rustup default nightly
-      - run: cargo doc --workspace --all-features --no-deps --document-private-items
+      - run: RUSTDOCFLAGS="-D warnings --cfg doc_cfg" cargo +nightly doc --all-features --no-deps --document-private-items # FIXME: Running this on the Tauri library does not work.
   lint:
     name: Lint (${{ matrix.os }} + ${{ matrix.channel }})
     needs: [format, format-cargo-toml, docs]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,10 @@ keywords = [""]
 description = "Manta Signer"
 publish = false
 
+[workspace]
+resolver = "2"
+members = ["ui/src-tauri"]
+
 [package.metadata.docs.rs]
 # To build locally:
 # RUSTDOCFLAGS="--cfg doc_cfg" cargo +nightly doc --all-features --open

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,11 +36,11 @@ derivative = { version = "2.2.0", default-features = false, features = ["use_cor
 dirs-next = { version = "2.0.0", default-features = false }
 futures = { version = "0.3.17", default-features = false, features = ["alloc"] }
 http-types = { version = "2.12.0", default-features = false }
-manta-accounting = { git = "https://github.com/manta-network/manta-rs", tag = "v0.5.4", default-features = false, features = ["cocoon-fs"] }
-manta-crypto = { git = "https://github.com/manta-network/manta-rs", tag = "v0.5.4", default-features = false, features = ["getrandom"] }
-manta-parameters = { git = "https://github.com/manta-network/manta-rs", tag = "v0.5.4", default-features = false, features = ["download"] }
-manta-pay = { git = "https://github.com/manta-network/manta-rs", tag = "v0.5.4", default-features = false, features = ["bs58", "groth16", "serde", "wallet"] }
-manta-util = { git = "https://github.com/manta-network/manta-rs", tag = "v0.5.4", default-features = false }
+manta-accounting = { git = "https://github.com/manta-network/manta-rs", tag = "v0.5.2", default-features = false, features = ["cocoon-fs"] }
+manta-crypto = { git = "https://github.com/manta-network/manta-rs", tag = "v0.5.2", default-features = false, features = ["getrandom"] }
+manta-parameters = { git = "https://github.com/manta-network/manta-rs", tag = "v0.5.2", default-features = false, features = ["download"] }
+manta-pay = { git = "https://github.com/manta-network/manta-rs", tag = "v0.5.2", default-features = false, features = ["bs58", "groth16", "serde", "wallet"] }
+manta-util = { git = "https://github.com/manta-network/manta-rs", tag = "v0.5.2", default-features = false }
 parking_lot = { version = "0.12.1", default-features = false }
 password-hash = { version = "0.4.2", default-features = false, features = ["alloc"] }
 secrecy = { version = "0.8.0", default-features = false, features = ["alloc"] }

--- a/src/service.rs
+++ b/src/service.rs
@@ -39,7 +39,7 @@ use manta_pay::{
         HierarchicalKeyDerivationFunction, Signer, SignerParameters, SignerState, UtxoAccumulator,
     },
 };
-use manta_util::{from_variant, serde::Serialize};
+use manta_util::{from_variant_impl, serde::Serialize};
 use parking_lot::Mutex;
 use std::{
     io,
@@ -95,10 +95,10 @@ pub enum Error {
     AuthorizationError,
 }
 
-from_variant!(Error, AddrParseError, AddrParseError);
-from_variant!(Error, JoinError, JoinError);
-from_variant!(Error, SaveError, SaveError<File>);
-from_variant!(Error, Io, io::Error);
+from_variant_impl!(Error, AddrParseError, AddrParseError);
+from_variant_impl!(Error, JoinError, JoinError);
+from_variant_impl!(Error, SaveError, SaveError<File>);
+from_variant_impl!(Error, Io, io::Error);
 
 impl From<Error> for tide::Error {
     #[inline]


### PR DESCRIPTION
Downgrade manta-rs
---

the type interfaces introduced in manta-rs v0.5.3 and higher are "ahed" of the type interfaces in Manta runtime

Before we can merge this PR, please make sure that all the following items have been checked off:

- [x] Linked to an issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Added **one** line describing your change in [`CHANGELOG.md`](https://github.com/manta-network/manta-signer/blob/main/CHANGELOG.md) and added the appropriate `changelog` label to the PR.
- [x] Re-reviewed `Files changed` in the GitHub PR explorer.
