### PR TITLE
Connection timeout after successful timeout fix

### DIFF
--- a/ui/src-tauri/src/main.rs
+++ b/ui/src-tauri/src/main.rs
@@ -96,12 +96,11 @@ impl AppState {
 /// Application State
 pub static APP_STATE: AppState = AppState::new();
 
-/// while with a timeout, best used for emitting events
-/// either for a response or other events to stop
-/// '$condition' does while true (block resulting in true or false)
-/// '$body' while body
-/// '$timeout' timeout
-/// '$falure' body after if while times out
+/// While with a timeout
+/// Loop over body code block until specified time elapses and exits executing a given code block
+/// Needs to be a macro to be able to break early in the main loop body code block
+/// i.e. loop over waiting to connect and then break the loop, or timeout with Error message after
+/// a specified time.
 macro_rules! while_w_timeout{
     ($body:block, $timeout_d:expr, $failure:block) => {{
         let time_start = Instant::now();
@@ -181,7 +180,7 @@ impl Authorizer for User {
             while_w_timeout!(
                 {
                     if APP_STATE.get_ui_connected() {
-                        break
+                        break;
                     }
                     window
                         .emit("connect", setup)

--- a/ui/src-tauri/src/main.rs
+++ b/ui/src-tauri/src/main.rs
@@ -181,13 +181,13 @@ impl Authorizer for User {
             while_w_timeout!(
                 {
                     if APP_STATE.get_ui_connected() {
-                        break;
+                        break
                     }
                     window
-                    .emit("connect", setup)
-                    .expect("The `connect` command failed to be emitted to the window.");
+                        .emit("connect", setup)
+                        .expect("The `connect` command failed to be emitted to the window.");
                 },
-                    5000,
+                5000,
                 {
                     panic!("Connection attempt timedout!");
                 }
@@ -346,4 +346,3 @@ fn main() {
         _ => (),
     })
 }
-


### PR DESCRIPTION
Fixing connection timeout after while_timeout was refactored wrong making it timeout even after succesful connection

Signed-off-by: Apokalip <simeon@manta.network>


fixes: #169 
---

Before we can merge this PR, please make sure that all the following items have been checked off:

- [x] Linked to an issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Added **one** line describing your change in [`CHANGELOG.md`](https://github.com/manta-network/manta-signer/blob/main/CHANGELOG.md) and added the appropriate `changelog` label to the PR.
- [x] Re-reviewed `Files changed` in the GitHub PR explorer.
