### PR TITLE
feat: add multiple origin URLs for CORS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased]
 
 ### Added
+- [\#180](https://github.com/Manta-Network/manta-signer/pull/180) Add support for mutliple CORS allowed origins
 
 ### Changed
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -72,7 +72,7 @@ impl Config {
             origin_urls: vec![],
             #[cfg(not(feature = "unsafe-disable-cors"))]
             origin_urls: vec![
-                "https://app.manta.network",
+                "https://app.manta.network".into(),
                 "https://app.dolphin.manta.network".into(),
             ],
         })

--- a/src/config.rs
+++ b/src/config.rs
@@ -50,10 +50,15 @@ pub struct Config {
     pub data_path: PathBuf,
 
     /// Service URL
+    ///
+    /// This URL defines the listening URL for the service.
     pub service_url: String,
 
-    /// Origin URL
-    pub origin_url: Option<String>,
+    /// Origin URLs
+    ///
+    /// These URLs are the allowed origins that can send requests to the service. An empty list
+    /// means any origin is allowed to send requests to the service.
+    pub origin_urls: Vec<String>,
 }
 
 impl Config {
@@ -64,9 +69,12 @@ impl Config {
             data_path: file(dirs_next::config_dir(), "storage.dat")?,
             service_url: "127.0.0.1:29987".into(),
             #[cfg(feature = "unsafe-disable-cors")]
-            origin_url: None,
+            origin_urls: vec![],
             #[cfg(not(feature = "unsafe-disable-cors"))]
-            origin_url: Some("https://app.dolphin.manta.network".into()),
+            origin_urls: vec![
+                "https://app.manta.network",
+                "https://app.dolphin.manta.network".into(),
+            ],
         })
     }
 

--- a/src/service.rs
+++ b/src/service.rs
@@ -257,9 +257,10 @@ where
         let socket_address = config.service_url.parse::<SocketAddr>()?;
         let cors = CorsMiddleware::new()
             .allow_methods("GET, POST".parse::<HeaderValue>().unwrap())
-            .allow_origin(match &config.origin_url {
-                Some(origin_url) => Origin::from(origin_url.as_str()),
-                _ => Origin::from("*"),
+            .allow_origin(if config.origin_urls.is_empty() {
+                Origin::Any
+            } else {
+                Origin::List(config.origin_urls)
             })
             .allow_credentials(false);
         let mut api = tide::Server::with_state(self);


### PR DESCRIPTION
Signed-off-by: Brandon H. Gomes <bhgomes@pm.me>

Adds https://app.manta.network to the CORS allowed origins setting and general support for multiple origins in the future.

---

Before we can merge this PR, please make sure that all the following items have been checked off:

- [x] Linked to an issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Added **one** line describing your change in [`CHANGELOG.md`](https://github.com/manta-network/manta-signer/blob/main/CHANGELOG.md) and added the appropriate `changelog` label to the PR.
- [x] Re-reviewed `Files changed` in the GitHub PR explorer.
