### PR TITLE
fix: check for old storage file before deleting it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 - [\#199](https://github.com/Manta-Network/manta-signer/pull/199) Fix unable to login to signer if close during state save
+- [\#204](https://github.com/Manta-Network/manta-signer/pull/204) Check for storage file before deleting it
 
 ### Security
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -117,7 +117,7 @@ impl Config {
                         fs::remove_file(self.data_path.clone()).await?;
                     }
                 }
-                
+
                 fs::rename(self.backup_data_path.clone(), self.data_path.clone()).await?;
                 Ok(true)
             }

--- a/src/config.rs
+++ b/src/config.rs
@@ -111,7 +111,13 @@ impl Config {
         fs::create_dir_all(self.data_directory()).await?;
         match fs::metadata(&self.backup_data_path).await {
             Ok(metadata) if metadata.is_file() => {
-                fs::remove_file(self.data_path.clone()).await?;
+                // need to check if old storage file still exists before deleting.
+                if let Ok(metadata) = fs::metadata(&self.data_path).await {
+                    if metadata.is_file() {
+                        fs::remove_file(self.data_path.clone()).await?;
+                    }
+                }
+                
                 fs::rename(self.backup_data_path.clone(), self.data_path.clone()).await?;
                 Ok(true)
             }


### PR DESCRIPTION
Fix to check for storage file before we delete it to replace it with backup file. This is an edge case where only the backup file exists without the storage file upon startup and would cause a crash if we tried to delete a non-existing storage file.

---

Before we can merge this PR, please make sure that all the following items have been checked off:

- [x] Linked to an issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Added **one** line describing your change in [`CHANGELOG.md`](https://github.com/manta-network/manta-signer/blob/main/CHANGELOG.md) and added the appropriate `changelog` label to the PR.
- [x] Re-reviewed `Files changed` in the GitHub PR explorer.
