### PR TITLE
Fix Missing File Reload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Removed
 
 ### Fixed
+- [\#236](https://github.com/Manta-Network/manta-signer/pull/236) Fix missing file reload
 
 ### Security
 

--- a/src/service.rs
+++ b/src/service.rs
@@ -336,15 +336,15 @@ where
 
                     let calamari_state = Self::create_or_load_state(
                         !data_exists.calamari,
-                        &config.data_path.dolphin,
+                        &config.data_path.calamari,
                         &password_hash,
                         recovery_mnemonic.clone(),
                     )
                     .await?;
 
                     let manta_state = Self::create_or_load_state(
-                        !data_exists.calamari,
-                        &config.data_path.dolphin,
+                        !data_exists.manta,
+                        &config.data_path.manta,
                         &password_hash,
                         recovery_mnemonic.clone(),
                     )


### PR DESCRIPTION
Signed-off-by: Charles Ferrell <charlie@manta.network>

Small bug fix with reloading a missing file. It mixes up different networks

---

Before we can merge this PR, please make sure that all the following items have been checked off:

- [x] Linked to an issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Added **one** line describing your change in [`CHANGELOG.md`](https://github.com/manta-network/manta-signer/blob/main/CHANGELOG.md) and added the appropriate `changelog` label to the PR.
- [x] Re-reviewed `Files changed` in the GitHub PR explorer.
