### PR TITLE
Fix reimport / password reset

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,6 +95,10 @@ jobs:
       - run: echo "SUFFIX ${{ steps.suffixed.outputs.SUFFIXED }}"
       - name: Append version suffix
         run: node ./scripts/suffix.js ${{ steps.suffixed.outputs.SUFFIXED }}
+      - name: Use Node.js 16.x
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16.x
       - name: Build & Sign
         run: cd ui;yarn && yarn tauri build -v
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Added
 
 ### Changed
+- [\#329](https://github.com/Manta-Network/manta-signer/pull/329) Fix bad sync after reimport or password reset
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,25 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+- [\#329](https://github.com/Manta-Network/manta-signer/pull/329) Fix bad sync after reimport or password reset
+
+### Security
+
 ## [1.1.1] 2023-02-13
 ### Added
 
 ### Changed
-- [\#329](https://github.com/Manta-Network/manta-signer/pull/329) Fix bad sync after reimport or password reset
 
 ### Deprecated
 

--- a/ui/src-tauri/src/main.rs
+++ b/ui/src-tauri/src/main.rs
@@ -504,6 +504,7 @@ async fn reset_account(
 
     if config.can_app_restart && restart {
         app_handle.restart();
+        return Ok(())
     }
 
     let (password_sender, password_receiver) = password_channel();

--- a/ui/src-tauri/src/main.rs
+++ b/ui/src-tauri/src/main.rs
@@ -504,7 +504,7 @@ async fn reset_account(
 
     if config.can_app_restart && restart {
         app_handle.restart();
-        return Ok(())
+        return Ok(());
     }
 
     let (password_sender, password_receiver) = password_channel();


### PR DESCRIPTION
Creating a server after restart, creates a bad app state so even after properly syncing, transactions would not pass. After restart there is no need for a new server, only case may be when we do a password reset where we do want to keep the password storage

closes: #330 

Before we can merge this PR, please make sure that all the following items have been checked off:

- [x] Linked to an issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Added **one** line describing your change in [`CHANGELOG.md`](https://github.com/manta-network/manta-signer/blob/main/CHANGELOG.md) and added the appropriate `changelog` label to the PR.
- [x] Re-reviewed `Files changed` in the GitHub PR explorer.
