### PR TITLE
Remove "soon" next to calamari for Calamari release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,19 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+### Changed
+- [\#348](https://github.com/Manta-Network/manta-signer/pull/348) Remove "soon" next to Calamari for release.
+
+### Deprecated
+
+### Removed
+
+### Security
+
 ## v1.2.0 2023-03-08
 
 ### Added

--- a/ui/src/pages/SignIn/SignInSuccess.js
+++ b/ui/src/pages/SignIn/SignInSuccess.js
@@ -45,7 +45,6 @@ const SignInSuccess = ({
             <tr>
               <th><img className='mini-calamari-logo' alt="Calamari Logo" src={calamariLogo} /></th>
               <th><p className='network-text'>&nbsp;Calamari Network&nbsp;&nbsp;</p></th>
-              <th><a href='https://calamari.network/' target="_blank" rel="noreferrer">(soon)</a></th>
             </tr>
             <tr>
               <th><img className='mini-manta-logo' alt="Manta Logo" src={mantaLogo} /></th>


### PR DESCRIPTION
---
Removes "soon" text next to Calamari now that is has been enabled

Before we can merge this PR, please make sure that all the following items have been checked off:

- [x] Linked to an issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Added **one** line describing your change in [`CHANGELOG.md`](https://github.com/manta-network/manta-signer/blob/main/CHANGELOG.md) and added the appropriate `changelog` label to the PR.
- [x] Re-reviewed `Files changed` in the GitHub PR explorer.